### PR TITLE
Add Verge cryptocurrency filter

### DIFF
--- a/comment_blocker.txt
+++ b/comment_blocker.txt
@@ -280,6 +280,7 @@ theverge.com##.coral-count:nth-ancestor(2)
 theverge.com##.duet--content-cards--content-card:has-text(/\b(elon|musk|doge)\b/i)
 theverge.com##.duet--content-cards--content-card:has(a[href*="/policy/"])
 theverge.com##.duet--content-cards--content-card:has(a[href*="/politics/"])
+theverge.com##.duet--content-cards--content-card:has(a[href*="/cryptocurrency"])
 
 ! Paywall
 theverge.com##.duet--content-cards--content-card:has(a[href*="/command-line-newsletter/"])


### PR DESCRIPTION
## Summary
- block cryptocurrency articles on The Verge

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447bc7c158832da8582f4892091e16